### PR TITLE
logging content improvements

### DIFF
--- a/ptero_common/logging_configuration.py
+++ b/ptero_common/logging_configuration.py
@@ -3,6 +3,7 @@ import requests
 from requests.models import Request
 import logging
 import os
+from pprint import pformat
 
 try:
     from flask import request
@@ -64,8 +65,8 @@ def logged_response(logger):
             response = Response(*result)
             logger.info("Responded %s to %s  %s",
                 response.status_code, target.__name__.upper(), request.url)
-            logger.debug("    Headers: '%s'", response.headers)
-            logger.debug("    Body: '%s'", response.get_data())
+            logger.debug("    Returning: %s",
+                         pformat(result, indent=2, width=80))
             return result
         return wrapper
     return _log_response

--- a/ptero_common/logging_configuration.py
+++ b/ptero_common/logging_configuration.py
@@ -83,9 +83,8 @@ def _log_request(target, kind):
         r = Request(kind.upper(), *args, **kwargs)
         logger.info("%s from %s  %s", response.status_code, kind.upper(), r.url)
         for name in ['params', 'headers', 'data']:
-            if getattr(r, name):
-                logger.debug("    %s%s: %s", name[0].upper(), name[1:],
-                        pformat(getattr(r, name), indent=2, width=80))
+            logger.debug("    %s%s: %s", name[0].upper(), name[1:],
+                         pformat(getattr(r, name), indent=2, width=80))
 
         return response
     return wrapper

--- a/ptero_common/logging_configuration.py
+++ b/ptero_common/logging_configuration.py
@@ -85,7 +85,7 @@ def _log_request(target, kind):
         for name in ['params', 'headers', 'data']:
             if getattr(r, name):
                 logger.debug("    %s%s: %s", name[0].upper(), name[1:],
-                        getattr(r, name))
+                        pformat(getattr(r, name), indent=2, width=80))
 
         return response
     return wrapper


### PR DESCRIPTION
The Response.get_data() function wasn't giving us the whole data, but a
list of keys in the data like so:

now

    DEBUG [ptero_workflow.api.v1.views]     Returning: ( { 'begins': [0],
        'color': 0,
        'colors': [0],
        'data': { u'petri_response_links': ...
        'inputs': { u'param': u'foo'},
        'method': { 'name': u'execute',
                    'service': u'shell-command',
                    'task': { 'name': u'C', 'type': u'method-list'}},
        'outputs': { u'param': u'foo'},
        'parent_color': None,
        'status': u'begun',
        'status_history': [ { 'status': u'begun',
                              'timestamp': '2015-01-28 01:07:18'}]},
      200)

was

    DEBUG [ptero_workflow.api.v1.views]     Body: 'beginscolorcolorsdatainputsmethodoutputsparent_colorstatusstatus_history'

which is not helpful.