### PR TITLE
fix a number of pep8 violations

### DIFF
--- a/ptero_common/devserver.py
+++ b/ptero_common/devserver.py
@@ -14,7 +14,7 @@ child_pids = set()
 def mkdir_p(path):
     try:
         os.makedirs(path)
-    except OSError as exc: # Python >2.5
+    except OSError as exc:  # Python >2.5
         if exc.errno == errno.EEXIST and os.path.isdir(path):
             pass
         else:
@@ -31,6 +31,7 @@ def shutdown():
     if signal_processes(child_pids, signal.SIGINT):
         time.sleep(3)
         signal_processes(child_pids, signal.SIGKILL)
+
 
 def signal_processes(pids, sig):
     signaled = []
@@ -49,11 +50,13 @@ def signal_processes(pids, sig):
     else:
         return False
 
+
 def expand_children():
     for p in child_pids.copy():
         try:
             process = psutil.Process(p)
-            child_pids.update([p.pid for p in process.get_children(recursive=True)])
+            child_pids.update(
+                [p.pid for p in process.get_children(recursive=True)])
         except psutil.NoSuchProcess:
             pass
 
@@ -73,9 +76,11 @@ def cleanup():
 
     shutdown()
 
+
 def log_and_cleanup(signum, frame):
     sys.stderr.write("RECEIVED SIGNAL: '%s'\n" % signum)
     cleanup()
+
 
 def setup_signal_handlers():
     signal.signal(signal.SIGINT, log_and_cleanup)
@@ -101,7 +106,8 @@ def run(logdir, procfile_path, workers):
         stdout=outlog, stderr=errlog)
     time.sleep(3)
     sys.stderr.write('The devserver is now up.\n')
-    child_pids.update([p.pid for p in psutil.Process().get_children(recursive=True)])
+    child_pids.update(
+        [p.pid for p in psutil.Process().get_children(recursive=True)])
 
     honcho_process.wait()
     cleanup()

--- a/ptero_common/janitors/base.py
+++ b/ptero_common/janitors/base.py
@@ -12,9 +12,9 @@ class Janitor(object):
         self.sanitized_url = self.sanitize_url(self.url_obj)
 
         if self.url_obj.scheme not in self.ALLOWED_SCHEMES:
-            raise JanitorException('Scheme "%s" not allowed.  '
-                    'Expected something from: %s' %
-                    (self.url_obj.scheme, self.ALLOWED_SCHEMES))
+            raise JanitorException(
+                'Scheme "%s" not allowed.  Expected something from: %s' %
+                (self.url_obj.scheme, self.ALLOWED_SCHEMES))
 
     @abc.abstractmethod
     def clean(self):  # pragma: no cover

--- a/ptero_common/janitors/exceptions.py
+++ b/ptero_common/janitors/exceptions.py
@@ -1,1 +1,2 @@
-class JanitorException(Exception): pass
+class JanitorException(Exception):
+    pass

--- a/ptero_common/janitors/rabbitmq_janitor.py
+++ b/ptero_common/janitors/rabbitmq_janitor.py
@@ -1,5 +1,5 @@
 from .base import Janitor
-from .exceptions import *
+from .exceptions import *  # noqa
 from urlparse import urljoin, urlunparse
 import logging
 import requests
@@ -24,9 +24,9 @@ class RabbitMQJanitor(Janitor):
 
     def __init__(self, url, api_port=15672):
         super(RabbitMQJanitor, self).__init__(url)
-        self.base_api_url = urlunparse(('http',
-            '%s:%s' % (self.url_obj.hostname, api_port),
-            '', '', '', ''))
+        self.base_api_url = urlunparse(
+            ('http', '%s:%s' % (self.url_obj.hostname, api_port),
+             '', '', '', ''))
 
     def clean(self):
         LOG.debug('Beginning purge of %s', self.sanitized_url)
@@ -114,8 +114,9 @@ class RabbitMQJanitor(Janitor):
         response = method(self.api_url(*parts), auth=self.api_auth())
 
         if int(response.status_code / 100) != 2:
-            LOG.error('Got unexpected response code (%s) from url %s: %s',
-                    response.status_code, self.api_url(*parts), response.text)
+            LOG.error(
+                'Got unexpected response code (%s) from url %s: %s',
+                response.status_code, self.api_url(*parts), response.text)
             raise JanitorException()
 
         if response.status_code == 204:

--- a/ptero_common/logging_configuration.py
+++ b/ptero_common/logging_configuration.py
@@ -26,6 +26,7 @@ def configure_celery_logging(service_name):
     logging.getLogger('kombu').setLevel(
         os.environ.get('PTERO_%s_KOMBU_LOG_LEVEL' % service_name, 'WARN'))
 
+
 def configure_web_logging(service_name):
     configure_logging(
         'PTERO_%s_LOG_LEVEL' % service_name,
@@ -63,7 +64,8 @@ def logged_response(logger):
                     target.__name__.upper(), request.url, request.data, str(e))
                 raise
             response = Response(*result)
-            logger.info("Responded %s to %s  %s",
+            logger.info(
+                "Responded %s to %s  %s",
                 response.status_code, target.__name__.upper(), request.url)
             logger.debug("    Returning: %s",
                          pformat(result, indent=2, width=80))

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,15 @@ commands =
     coverage run {envbindir}/nosetests {posargs}
     coverage combine
     coverage report
+    flake8
 
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
+    flake8
+
+[flake8]
+max-line-length = 80
+exclude = *.egg
+max-complexity = 8
+ignore =


### PR DESCRIPTION
./ptero_common/devserver.py:17:27: E261 at least two spaces before inline comment
./ptero_common/devserver.py:35:1: E302 expected 2 blank lines, found 1
./ptero_common/devserver.py:52:1: E302 expected 2 blank lines, found 1
./ptero_common/devserver.py:56:81: E501 line too long (84 > 80 characters)
./ptero_common/devserver.py:76:1: E302 expected 2 blank lines, found 1
./ptero_common/devserver.py:80:1: E302 expected 2 blank lines, found 1
./ptero_common/devserver.py:104:81: E501 line too long (85 > 80 characters)
./ptero_common/logging_configuration.py:29:1: E302 expected 2 blank lines, found 1
./ptero_common/logging_configuration.py:67:17: E128 continuation line under-indented for visual indent
./ptero_common/janitors/base.py:16:21: E128 continuation line under-indented for visual indent
./ptero_common/janitors/base.py:17:21: E128 continuation line under-indented for visual indent
./ptero_common/janitors/exceptions.py:1:34: E701 multiple statements on one line (colon)
./ptero_common/janitors/rabbitmq_janitor.py:2:1: F403 'from exceptions import *' used; unable to detect undefined names
./ptero_common/janitors/rabbitmq_janitor.py:28:13: E128 continuation line under-indented for visual indent
./ptero_common/janitors/rabbitmq_janitor.py:118:21: E128 continuation line under-indented for visual indent