### PR TITLE
Use python_daemon to daemonize devserver

### DIFF
--- a/ptero_common/devserver.py
+++ b/ptero_common/devserver.py
@@ -98,12 +98,14 @@ def run(logdir, procfile_path, workers, daemondir=None):
         with daemon.DaemonContext(
                 working_directory='.',
                 umask=0o002,
-                pidfile=lockfile.FileLock(os.path.join(daemondir, 'devserver.pid')),
+                pidfile=lockfile.FileLock(
+                    os.path.join(daemondir, 'devserver.pid')),
                 stdout=open(os.path.join(daemondir, 'devserver.out'), 'w'),
                 stderr=open(os.path.join(daemondir, 'devserver.err'), 'w')):
             _run(logdir, procfile_path, workers)
     else:
         _run(logdir, procfile_path, workers)
+
 
 def _run(logdir, procfile_path, workers):
     global honcho_process

--- a/ptero_common/devserver.py
+++ b/ptero_common/devserver.py
@@ -15,7 +15,7 @@ child_pids = set()
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('--num-http-workers', type=int, default=2)
-    parser.add_argument('--num-submit-workers', type=int, default=2)
+    parser.add_argument('--num-workers', type=int, default=2)
     parser.add_argument('--logdir', default='-')
     parser.add_argument('--daemondir')
     parser.add_argument('--procfile')
@@ -151,7 +151,7 @@ def main():
         logdir=arguments.logdir,
         workers={
             'http_worker': arguments.num_http_workers,
-            'submit_worker': arguments.num_submit_workers,
+            'worker': arguments.num_workers,
         },
         procfile_path=arguments.procfile,
         daemondir=arguments.daemondir)

--- a/ptero_common/devserver.py
+++ b/ptero_common/devserver.py
@@ -1,3 +1,4 @@
+import argparse
 import errno
 import os
 import sys
@@ -9,6 +10,16 @@ import lockfile
 
 honcho_process = None
 child_pids = set()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--num-http-workers', type=int, default=2)
+    parser.add_argument('--num-submit-workers', type=int, default=2)
+    parser.add_argument('--logdir', default='-')
+    parser.add_argument('--daemondir')
+    parser.add_argument('--procfile')
+    return parser.parse_args()
 
 
 # This is from a stackoverflow answer:
@@ -131,3 +142,16 @@ def _run(logdir, procfile_path, workers):
 
     honcho_process.wait()
     cleanup()
+
+
+def main():
+    arguments = parse_args()
+
+    run(
+        logdir=arguments.logdir,
+        workers={
+            'http_worker':arguments.num_http_workers,
+            'submit_worker':arguments.num_submit_workers,
+        },
+        procfile_path=arguments.procfile,
+        daemondir=arguments.daemondir)

--- a/ptero_common/devserver.py
+++ b/ptero_common/devserver.py
@@ -150,8 +150,8 @@ def main():
     run(
         logdir=arguments.logdir,
         workers={
-            'http_worker':arguments.num_http_workers,
-            'submit_worker':arguments.num_submit_workers,
+            'http_worker': arguments.num_http_workers,
+            'submit_worker': arguments.num_submit_workers,
         },
         procfile_path=arguments.procfile,
         daemondir=arguments.daemondir)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ flask
 honcho
 psutil
 termcolor
+python_daemon

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,7 @@ packages =
 [global]
 setup-hooks =
     pbr.hooks.setup_hook
+
+[entry_points]
+console_scripts =
+    devserver = ptero_common.devserver:main


### PR DESCRIPTION
This is api-breaking, it now takes a daemondir argument instead of a
pidfile argument, because I needed to supply a directory for the stdout
and stderr file as well as the lock files associated with the pidfile.