### PR TITLE
Added scripts useful in tox.ini files

### DIFF
--- a/scripts/teardown_devserver
+++ b/scripts/teardown_devserver
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+PID=$(cat $1 2>/dev/null)
+
+test -z $PID && echo "No devserver found to be running." && exit 0
+
+echo -n "Killing devserver with PID: $PID "
+
+kill $PID
+
+while ps -p $PID >/dev/null; do
+    echo -n "."
+    sleep 1
+done
+
+echo

--- a/scripts/wait_for_service
+++ b/scripts/wait_for_service
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+WAIT_HOST=$(eval echo \${$1})
+WAIT_PORT=$(eval echo \${$2})
+
+echo -n "Waiting for service at $WAIT_HOST:$WAIT_PORT"
+
+until echo dummy-value 2>/dev/null | nc $WAIT_HOST $WAIT_PORT >/dev/null 2>&1; do
+    echo -n "."
+    sleep 1
+done
+
+echo

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,10 +6,14 @@ summary = Common code for Ptero services
 [files]
 packages =
     ptero_common
+scripts =
+    scripts/teardown_devserver
+    scripts/wait_for_service
 
 [global]
 setup-hooks =
     pbr.hooks.setup_hook
+
 
 [entry_points]
 console_scripts =


### PR DESCRIPTION
teardown_devserver <pidfile>
wait_for_service <host_env_var> <port_env_var>

Because tox's `commands` section has no access to the `setenv` section, we
have to pass just the name of the env variables to `wait_for_service`