### PR TITLE
Add utility to format dictionaries of lists

### DIFF
--- a/ptero_common/logging_configuration.py
+++ b/ptero_common/logging_configuration.py
@@ -83,7 +83,8 @@ def logged_response(logger):
                 logger.exception(
                     "Unexpected exception while handling %s  %s:\n"
                     "Body: %s\n%s",
-                    target.__name__.upper(), request.url, request._cached_data, str(e))
+                    target.__name__.upper(), request.url,
+                    request._cached_data, str(e))
                 raise
             response = Response(*result)
             logger.info(

--- a/ptero_common/utils.py
+++ b/ptero_common/utils.py
@@ -1,0 +1,9 @@
+
+def format_dict_of_lists(data):
+    result = {}
+    for key, value in data.iteritems():
+        if len(value) == 1:
+            result[key] = value[0]
+        else:
+            result[key] = sorted(value)
+    return result


### PR DESCRIPTION
We often have dictionaries of lists of strings (webhooks and
link.dataFlow), and we want to sort the strings in the list or, if the
list has only one item, we want to make it a scalar.