### PR TITLE
Janitor spec

### DIFF
--- a/ptero_common/janitors/__init__.py
+++ b/ptero_common/janitors/__init__.py
@@ -16,12 +16,12 @@ def perform_cleanup(janitor_spec):
     validate_allowed(args.force)
     validate_janitor_spec(janitor_spec)
 
-    for janitor_name,janitor in janitor_spec.iteritems():
+    for janitor_name, janitor in janitor_spec.iteritems():
         if janitor['do_cleanup']:
             _perform_cleanup(janitor_name, janitor)
 
 
-def _perform_cleanup(janitor_name,janitor):
+def _perform_cleanup(janitor_name, janitor):
     try:
         janitor['cleanup_action']()
     except:
@@ -48,9 +48,10 @@ def validate_environment(required_envvar_names):
 
 
 def validate_janitor_spec(janitor_spec):
-    for janitor_name,janitor in janitor_spec.iteritems():
+    for janitor_name, janitor in janitor_spec.iteritems():
         if janitor['do_cleanup']:
             _validate_janitor_spec(janitor_name, janitor)
+
 
 def _validate_janitor_spec(janitor_name, janitor):
     if janitor['required_envvars']:
@@ -78,6 +79,6 @@ def parse_args(janitor_spec):
 
     for k in janitor_spec.keys():
         janitor_spec[k].update({'do_cleanup':
-            getattr(args,k) or args.all})
+            getattr(args, k) or args.all})
 
     return args

--- a/ptero_common/janitors/rabbitmq_janitor.py
+++ b/ptero_common/janitors/rabbitmq_janitor.py
@@ -18,6 +18,7 @@ class RabbitMQJanitor(Janitor):
         'amq.fanout',
         'amq.headers',
         'amq.match',
+        'amq.rabbitmq.log',
         'amq.rabbitmq.trace',
         'amq.topic',
     }


### PR DESCRIPTION
perform_cleanup() now only accepts one argument, which is a janitor_spec
data structure which declare the environment variables that are required to
be set for cleanup and also provides a callable function for performing
the cleanup.

Example:

```perl
perform_cleanup(janitor_spec={
    'postgres': {
        'required_envvars': ['PTERO_LSF_DB_STRING'],
        'cleanup_action': lambda: PostgresJanitor(
            os.environ['PTERO_LSF_DB_STRING']).clean(),
        },
    })
```

The purpose of changing the perform_cleanup() API is to allow for better
argument parsing in the Janitor.  Now the purge-backends scripts accept as
arguments the backends which should be cleaned or --all to run the janitor for
all of the backends.

Example usages:
```
$ PTERO_LSF_DB_STRING=postgres:/dbhost/  purge-backends --postgres

-or-

$ PTERO_LSF_DB_STRING=postgres:/dbhost/  purge-backends --all
```