### PR TITLE
Move server_info logic here from ptero_workflow

### DIFF
--- a/ptero_common/server_info.py
+++ b/ptero_common/server_info.py
@@ -1,0 +1,31 @@
+from pip.commands.freeze import freeze
+import datetime
+import os
+import psutil
+import subprocess
+
+
+def get_server_info(celery_app_import_path):
+    p = psutil.Process()
+    started = datetime.datetime.fromtimestamp(p.create_time())
+    uptime = str(datetime.datetime.now() - started)
+    started_str = started.strftime("%Y-%m-%d %H:%M:%S")
+
+    installed_modules = [l for l in freeze()]
+
+    celery_status = subprocess.check_output(['celery', '-A',
+        celery_app_import_path, '--no-color', '--timeout=1', 'status'])
+    celery_status_list = [s for s in celery_status.split('\n') if len(s)]
+
+    if 'GIT_SHA' in os.environ:
+        git_sha = os.environ['GIT_SHA']
+    else:
+        git_sha = 'Unknown'
+
+    return {
+            'celeryStatus': celery_status_list,
+            'gitSha': git_sha,
+            'installedModules': installed_modules,
+            'startedAt': started_str,
+            'uptime': uptime,
+            }


### PR DESCRIPTION
This will make it easier to implement server-info endpoints for the
other services.  I didn't include 'databaseRevision' because Petri
doesn't have a database and I wanted to include only things that all
services share.