### PR TITLE
Celery commom config

### DIFF
--- a/ptero_common/celery/utils.py
+++ b/ptero_common/celery/utils.py
@@ -6,6 +6,8 @@ LOG = nicer_logging.getLogger(__name__)
 
 _CONFIGURATION_NAMES = {
         'CELERY_BROKER_URL': 'BROKER_URL',
+        'CELERY_BROKER_HEARTBEAT': 'BROKER_HEARTBEAT',
+        'CELERY_BROKER_HEARTBEAT_CHECKRATE': 'BROKER_HEARTBEAT_CHECKRATE',
 }
 
 
@@ -33,6 +35,8 @@ def _bool_formatter(value):
 _FORMATTERS = {
         'CELERY_ACCEPT_CONTENT': _list_formatter,
         'CELERY_ACKS_LATE': _bool_formatter,
+        'BROKER_HEARTBEAT': float,
+        'BROKER_HEARTBEAT_CHECKRATE': float,
         'CELERY_PREFETCH_MULTIPLIER': int,
         'CELERY_TRACK_STARTED': _bool_formatter,
 }

--- a/ptero_common/celery/utils.py
+++ b/ptero_common/celery/utils.py
@@ -46,7 +46,7 @@ def _get_formatter(config_name):
     return _FORMATTERS.get(config_name, _default_formatter)
 
 
-def get_config_from_env(service_name):
+def _get_config_from_env(service_name):
     result = {}
     for env_var_name, env_var_value in os.environ.iteritems():
         if re.match('PTERO_%s_CELERY' % service_name, env_var_name):
@@ -60,3 +60,15 @@ def get_config_from_env(service_name):
                     config_name, str(config_value), env_var_name, env_var_value)
 
     return result
+
+
+def get_celery_config(service_name):
+    config = _get_config_from_env(service_name)
+    config.update({
+        'BROKER_TRANSPORT_OPTIONS': {'confirm_publish': True},
+        'CELERY_ACCEPT_CONTENT': ['json'],
+        'CELERY_ACKS_LATE': True,
+        'CELERY_RESULT_SERIALIZER': 'json',
+        'CELERY_TASK_SERIALIZER': 'json',
+        })
+    return config


### PR DESCRIPTION
I tested this PR locally against the ptero-petri repo.  I checked that configuration is being set correctly by adding a debug print to the petri celery_app.py which prints the results of `app.conf.humanize(with_defaults=True, censored=False)`.  Here is an abridged version of that debug print showing the configuration variables that we're setting from ptero-common now, and the new broker heartbeat configuration:

```
11:10:28 http_worker.1       | CELERY_TASK_SERIALIZER: 'json'
11:10:28 http_worker.1       | CELERY_RESULT_SERIALIZER: 'json'
11:10:28 http_worker.1       | BROKER_TRANSPORT_OPTIONS: {
11:10:28 http_worker.1       |     'confirm_publish': True}
11:10:28 http_worker.1       | BROKER_HEARTBEAT: 300.0
11:10:28 http_worker.1       | CELERY_EVENT_SERIALIZER: 'json'
11:10:28 http_worker.1       | CELERY_ACCEPT_CONTENT: ['json']
11:10:28 http_worker.1       | CELERY_ACKS_LATE: True
11:10:28 http_worker.1       | BROKER_HEARTBEAT_CHECKRATE: 5.0
```