### PR TITLE
Http logging

### DIFF
--- a/ptero_common/celery/http.py
+++ b/ptero_common/celery/http.py
@@ -39,7 +39,8 @@ class HTTP(celery.Task):
                 "A ConnectionError occured for while attempting to send "
                 "%s  %s, retrying in %s seconds. Attempt %d of %d.",
                 method.upper(), url, delay, self.request.retries + 1,
-                self.max_retries + 1)
+                self.max_retries + 1, extra={"method": method.upper(),
+                    "url": url})
             self.retry(throw=False, countdown=delay)
 
         if response.status_code in CODES_TO_RETRY:
@@ -47,7 +48,8 @@ class HTTP(celery.Task):
             LOG.warning(
                 "Got response (%s), retrying in %s seconds.  Attempt %d of %d.",
                 response.status_code, delay, self.request.retries + 1,
-                self.max_retries + 1)
+                self.max_retries + 1, extra={"method": method.upper(),
+                    "status_code": respsonse.status_code, "url": url})
             self.retry(throw=False, countdown=delay)
 
         response_info = {
@@ -61,7 +63,8 @@ class HTTP(celery.Task):
 
         if response.status_code < 200 or response.status_code >= 300:
             LOG.warning("Got response (%s), returning response info.",
-                     response.status_code)
+                    response.status_code, extra={"method": method.upper(),
+                    "status_code": respsonse.status_code, "url": url})
             return response_info
         elif not self.ignore_result:
             LOG.info("Got response (%s), returning json decoded response info.",

--- a/ptero_common/celery/http.py
+++ b/ptero_common/celery/http.py
@@ -69,7 +69,8 @@ class HTTP(celery.Task):
             response_info["json"] = response.json()
             return response_info
         else:
-            LOG.info("Got response (%s), ignoring result.", response.status_code)
+            LOG.info("Got response (%s), ignoring result.",
+                    response.status_code)
             return
 
     def body(self, kwargs):

--- a/ptero_common/celery/http.py
+++ b/ptero_common/celery/http.py
@@ -28,7 +28,6 @@ class HTTP(celery.Task):
 
     def run(self, method, url, **kwargs):
         try:
-            LOG.info("Submitting HTTP %s request to %s", method.upper(), url)
             response = getattr(logged_request, method.lower())(
                 url, data=self.body(kwargs),
                 headers={'Content-Type': 'application/json'},
@@ -67,13 +66,9 @@ class HTTP(celery.Task):
                     "status_code": respsonse.status_code, "url": url})
             return response_info
         elif not self.ignore_result:
-            LOG.info("Got response (%s), returning json decoded response info.",
-                     response.status_code)
             response_info["json"] = response.json()
             return response_info
         else:
-            LOG.info("Got response (%s), ignoring result.",
-                    response.status_code)
             return
 
     def body(self, kwargs):

--- a/ptero_common/celery/http.py
+++ b/ptero_common/celery/http.py
@@ -28,6 +28,7 @@ class HTTP(celery.Task):
 
     def run(self, method, url, **kwargs):
         try:
+            LOG.info("Submitting HTTP %s request to %s", method.upper(), url)
             response = getattr(logged_request, method.lower())(
                 url, data=self.body(kwargs),
                 headers={'Content-Type': 'application/json'},
@@ -63,9 +64,12 @@ class HTTP(celery.Task):
                      response.status_code)
             return response_info
         elif not self.ignore_result:
+            LOG.info("Got response (%s), returning json decoded response info.",
+                     response.status_code)
             response_info["json"] = response.json()
             return response_info
         else:
+            LOG.info("Got response (%s), ignoring result.", response.status_code)
             return
 
     def body(self, kwargs):

--- a/ptero_common/celery/http.py
+++ b/ptero_common/celery/http.py
@@ -48,7 +48,7 @@ class HTTP(celery.Task):
                 "Got response (%s), retrying in %s seconds.  Attempt %d of %d.",
                 response.status_code, delay, self.request.retries + 1,
                 self.max_retries + 1, extra={"method": method.upper(),
-                    "status_code": respsonse.status_code, "url": url})
+                    "status_code": response.status_code, "url": url})
             self.retry(throw=False, countdown=delay)
 
         response_info = {
@@ -63,7 +63,7 @@ class HTTP(celery.Task):
         if is_not_200(response.status_code):
             LOG.warning("Got response (%s), returning response info.",
                     response.status_code, extra={"method": method.upper(),
-                    "status_code": respsonse.status_code, "url": url})
+                    "status_code": response.status_code, "url": url})
             return response_info
         elif not self.ignore_result:
             response_info["json"] = response.json()

--- a/ptero_common/celery/http.py
+++ b/ptero_common/celery/http.py
@@ -60,7 +60,7 @@ class HTTP(celery.Task):
             "headers": lowercase_dict(response.headers),
         }
 
-        if response.status_code < 200 or response.status_code >= 300:
+        if is_not_200(response.status_code):
             LOG.warning("Got response (%s), returning response info.",
                     response.status_code, extra={"method": method.upper(),
                     "status_code": respsonse.status_code, "url": url})
@@ -73,6 +73,10 @@ class HTTP(celery.Task):
 
     def body(self, kwargs):
         return json.dumps(kwargs)
+
+
+def is_not_200(status_code):
+    return status_code < 200 or 300 <= status_code
 
 
 def lowercase_dict(dict_like):

--- a/ptero_common/celery/http.py
+++ b/ptero_common/celery/http.py
@@ -34,7 +34,7 @@ class HTTP(celery.Task):
                 timeout=10, logger=LOG)
         except ConnectionError:
             delay = DELAYS[self.request.retries]
-            LOG.info(
+            LOG.exception(
                 "A ConnectionError occured for while attempting to send "
                 "%s  %s, retrying in %s seconds. Attempt %d of %d.",
                 method.upper(), url, delay, self.request.retries + 1,
@@ -43,7 +43,7 @@ class HTTP(celery.Task):
 
         if response.status_code in CODES_TO_RETRY:
             delay = DELAYS[self.request.retries]
-            LOG.info(
+            LOG.warning(
                 "Got response (%s), retrying in %s seconds.  Attempt %d of %d.",
                 response.status_code, delay, self.request.retries + 1,
                 self.max_retries + 1)
@@ -59,7 +59,7 @@ class HTTP(celery.Task):
         }
 
         if response.status_code < 200 or response.status_code >= 300:
-            LOG.info("Got response (%s), returning response info.",
+            LOG.warning("Got response (%s), returning response info.",
                      response.status_code)
             return response_info
         elif not self.ignore_result:

--- a/ptero_common/logging_configuration.py
+++ b/ptero_common/logging_configuration.py
@@ -20,8 +20,11 @@ def configure_celery_logging(service_name):
         os.environ.get('PTERO_%s_KOMBU_LOG_LEVEL' % service_name, 'WARN'))
     logging.getLogger('sqlalchemy.engine').setLevel(
         os.environ.get('PTERO_%s_ORM_LOG_LEVEL' % service_name, 'WARN'))
-    logging.getLogger('ptero_common.celery.http').setLevel(
-        os.environ.get('PTERO_%s_HTTP_LOG_LEVEL' % service_name, 'WARN'))
+
+    env_var_name = 'PTERO_%s_HTTP_LOG_LEVEL' % service_name
+    if env_var_name in os.environ:
+        logging.getLogger('ptero_common.celery.http').setLevel(
+                os.environ[env_var_name])
 
 
 def configure_web_logging(service_name):

--- a/ptero_common/logging_configuration.py
+++ b/ptero_common/logging_configuration.py
@@ -20,6 +20,8 @@ def configure_celery_logging(service_name):
         os.environ.get('PTERO_%s_KOMBU_LOG_LEVEL' % service_name, 'WARN'))
     logging.getLogger('sqlalchemy.engine').setLevel(
         os.environ.get('PTERO_%s_ORM_LOG_LEVEL' % service_name, 'WARN'))
+    logging.getLogger('ptero_common.celery.http').setLevel(
+        os.environ.get('PTERO_%s_HTTP_LOG_LEVEL' % service_name, 'WARN'))
 
 
 def configure_web_logging(service_name):

--- a/ptero_common/nicer_logging.py
+++ b/ptero_common/nicer_logging.py
@@ -101,14 +101,13 @@ def _log_request(target, kind):
         request = Request(kind.upper(), *args, **kwargs_for_constructor)
 
         def log_with_extra(callable, *_args, **_kwargs):
-            extra={"method": kind.upper(), "url": request.url}
+            extra = {"method": kind.upper(), "url": request.url}
 
             if "extra" in _kwargs:
                 extra.update(_kwargs["extra"])
 
             _kwargs["extra"] = extra
             return callable(*_args, **_kwargs)
-
 
         label = '%s %s' % (kind.upper(), request.url)
         log_with_extra(logger.info, "Submitting HTTP %s", label)

--- a/ptero_common/nicer_logging.py
+++ b/ptero_common/nicer_logging.py
@@ -93,11 +93,7 @@ def _log_request(target, kind):
         if 'logger' in kwargs:
             del kwargs['logger']
 
-        kwargs_for_constructor = kwargs.copy()
-        if 'timeout' in kwargs_for_constructor:
-            # timout is an argument to requests.get/post/ect but not
-            # Request.__init__
-            del kwargs_for_constructor['timeout']
+        kwargs_for_constructor = get_args_for_request_constructor(kwargs)
         request = Request(kind.upper(), *args, **kwargs_for_constructor)
 
         def log_with_extra(callable, *_args, **_kwargs):
@@ -139,6 +135,15 @@ def _log_request(target, kind):
 
         return response
     return wrapper
+
+
+def get_args_for_request_constructor(kwargs):
+    kwargs_for_constructor = kwargs.copy()
+    if 'timeout' in kwargs_for_constructor:
+        # timout is an argument to requests.get/post/ect but not
+        # Request.__init__
+        del kwargs_for_constructor['timeout']
+    return kwargs_for_constructor
 
 
 class LoggedRequest(object):


### PR DESCRIPTION
Enables optional logging of typical http requests and responses on a per service level.  All existing logging has been moved to WARN level or greater.  New INFO logging added to log requests and responses.

To set extra logging: `PTERO_WORKFLOW_HTTP_LOG_LEVEL=INFO`