### PR TITLE
Ensure we return after self.retry

### DIFF
--- a/ptero_common/celery/http.py
+++ b/ptero_common/celery/http.py
@@ -42,6 +42,7 @@ class HTTP(celery.Task):
                 self.request.retries + 1, self.max_retries + 1,
                 extra={"method": method.upper(), "url": url})
             self.retry(throw=False, countdown=delay)
+            return
 
         if response.status_code in CODES_TO_RETRY:
             delay = DELAYS[self.request.retries]
@@ -51,6 +52,7 @@ class HTTP(celery.Task):
                 self.max_retries + 1, extra={"method": method.upper(),
                     "status_code": response.status_code, "url": url})
             self.retry(throw=False, countdown=delay)
+            return
 
         response_info = {
             "method": method,


### PR DESCRIPTION
In the case that someone is waiting on this task's result, not returning
could raise an exception which gets passed back as a result.  Celery
will then retry the task anyways, but the result (exception) will have been
recieved and the retrying task's result ignored.
